### PR TITLE
Feature/SNS-92 Terraform Deployment [UPDATE]

### DIFF
--- a/deployment/alb.tf
+++ b/deployment/alb.tf
@@ -1,11 +1,8 @@
 resource "aws_alb" "application_load_balancer" {
   name               = "Raw-Data-Server-LB"
   load_balancer_type = "application"
-  subnets = [
-    aws_default_subnet.default_subnet_1.id,
-    aws_default_subnet.default_subnet_2.id
-  ]
-  security_groups = [aws_security_group.load_balancer_security_group.id]
+  subnets            = aws_default_subnet.default_subnet.*.id
+  security_groups    = [aws_security_group.load_balancer_security_group.id]
 }
 
 resource "aws_security_group" "load_balancer_security_group" {

--- a/deployment/ecs.tf
+++ b/deployment/ecs.tf
@@ -3,8 +3,8 @@ resource "aws_ecs_cluster" "rds_cluster" {
 }
 
 resource "random_password" "raw_data_server_db_password" {
-  length = 12
-  special = true
+  length           = 12
+  special          = true
   override_special = "_%@"
 }
 
@@ -32,8 +32,14 @@ resource "aws_ecs_service" "rds_service" {
     container_port   = var.app_container_port
   }
 
+  load_balancer {
+    target_group_arn = aws_lb_target_group.target_group_db.arn
+    container_name   = "rds-db"
+    container_port   = 3306
+  }
+
   network_configuration {
-    subnets          = [aws_default_subnet.default_subnet_1.id, aws_default_subnet.default_subnet_2.id]
+    subnets          = aws_default_subnet.default_subnet.*.id
     assign_public_ip = true
     security_groups  = [aws_security_group.service_security_group.id]
   }
@@ -134,6 +140,13 @@ resource "aws_security_group" "service_security_group" {
   ingress {
     from_port   = 2049
     to_port     = 2049
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 3306
+    to_port     = 3306
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }

--- a/deployment/efs.tf
+++ b/deployment/efs.tf
@@ -6,19 +6,14 @@ resource "aws_efs_file_system" "rds_fs" {
   }
 }
 
-resource "aws_efs_mount_target" "mount_1" {
+resource "aws_efs_mount_target" "mount" {
+  count          = length(var.aws_availability_zones)
   file_system_id = aws_efs_file_system.rds_fs.id
-  subnet_id      = aws_default_subnet.default_subnet_1.id
+  subnet_id      = aws_default_subnet.default_subnet[count.index].id
 
   security_groups = [aws_security_group.service_security_group.id]
 }
 
-resource "aws_efs_mount_target" "mount_2" {
-  file_system_id = aws_efs_file_system.rds_fs.id
-  subnet_id      = aws_default_subnet.default_subnet_2.id
-
-  security_groups = [aws_security_group.service_security_group.id]
-}
 
 resource "aws_efs_access_point" "rds_eap" {
   file_system_id = aws_efs_file_system.rds_fs.id

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -12,11 +12,7 @@ resource "aws_default_vpc" "default_vpc" {
 }
 
 # Providing a reference to our default subnets
-
-resource "aws_default_subnet" "default_subnet_1" {
-  availability_zone = "us-west-1b"
-}
-
-resource "aws_default_subnet" "default_subnet_2" {
-  availability_zone = "us-west-1c"
+resource "aws_default_subnet" "default_subnet" {
+  count             = length(var.aws_availability_zones)
+  availability_zone = var.aws_availability_zones[count.index]
 }

--- a/deployment/nlb.tf
+++ b/deployment/nlb.tf
@@ -1,0 +1,24 @@
+resource "aws_lb" "network_load_balancer" {
+  name               = "Raw-Data-Server-NLB"
+  load_balancer_type = "network"
+  subnets            = aws_default_subnet.default_subnet.*.id
+}
+
+
+resource "aws_lb_target_group" "target_group_db" {
+  name        = "target-group-db"
+  port        = 3306
+  protocol    = "TCP"
+  target_type = "ip"
+  vpc_id      = aws_default_vpc.default_vpc.id
+}
+
+resource "aws_lb_listener" "listener_db" {
+  load_balancer_arn = aws_lb.network_load_balancer.arn
+  port              = "3306"
+  protocol          = "TCP"
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.target_group_db.arn
+  }
+}

--- a/deployment/variable.tf
+++ b/deployment/variable.tf
@@ -1,6 +1,11 @@
 variable "aws_region" {
-  default     = "us-west-1"
+  default     = "us-east-1"
   description = "Which region should the resources be deployed into?"
+}
+
+variable "aws_availability_zones" {
+  default     = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  description = "Availability zone list"
 }
 
 variable "db_username" {
@@ -19,13 +24,13 @@ variable "app_container_port" {
 }
 
 variable "s3_access_key_id" {
-  type = string
+  type    = string
 }
 
 variable "s3_secret_key" {
-  type = string
+  type    = string
 }
 
 variable "s3_bucket" {
-  type = string
+  type    = string
 }


### PR DESCRIPTION
- Added Load Balancer of type Network to direct TCP Connection to ECS Service of MySQL (port 3306)
We can access the database directly now using the dns of network load balancer:
![image](https://user-images.githubusercontent.com/46771684/121673174-d464f700-cada-11eb-9a0f-b35e2e12214b.png)
- Changed default variable to us-east-1
- Updated configs to be more dependant on variables, we can just define the subnets and region from the variables now