### PR TITLE
SNS-485: ability to re-executable updateMetasailUrls

### DIFF
--- a/scripts/updateRawDataServerDB/updateMetasailUrls.js
+++ b/scripts/updateRawDataServerDB/updateMetasailUrls.js
@@ -11,12 +11,13 @@ const updateMetasailUrls = async () => {
   });
 
   for (const race of existingRaces) {
-    const transaction = await db.sequelize.transaction();
+    let transaction;
     try {
       const url = race.url.replace('http://', 'https://');
 
       // only update http race
       if (race.url.indexOf('https') === -1) {
+        transaction = await db.sequelize.transaction();
         await db.metasailRace.update(
           {
             url,
@@ -35,7 +36,9 @@ const updateMetasailUrls = async () => {
       });
     } catch (error) {
       console.log(error.toString());
-      await transaction.rollback();
+      if (transaction) {
+        await transaction.rollback();
+      }
       errorMessage = databaseErrorHandler(error);
     }
   }


### PR DESCRIPTION
1. I added ability to re-executable updateMetasailUrls. So instead of http url from MetasailRac table. I will get all races and update it once again. This fix is aim to update the url of elastic search.
2. We have around 2772 metasail races in production, so I think it is not a problem to run it entirely once again.