### PR TITLE
SNS-486: optimize _getRaceQsPosition, add more log to understand the …

### DIFF
--- a/scripts/saveToMainDB/raceQsSaveToMainDB.js
+++ b/scripts/saveToMainDB/raceQsSaveToMainDB.js
@@ -1,13 +1,11 @@
 require('dotenv').config();
 const db = require('../../src/models');
-const Op = db.Sequelize.Op;
 const { SOURCE, RACEQS } = require('../../src/constants');
 const { getExistingData } = require('../../src/services/scrapedDataResult');
 const mapRaceQsToSyrf = require('../../src/services/mappingsToSyrfDB/mapRaceQsToSyrf');
 const {
   normalizeRace,
 } = require('../../src/services/normalization/normalizeRaceQs');
-const { logFunctionTime } = require('../../src/utils/logUtils');
 
 const elasticsearch = require('../../src/utils/elasticsearch');
 (async () => {
@@ -135,13 +133,13 @@ const elasticsearch = require('../../src/utils/elasticsearch');
           // in case there is a start in division, raceId = start.id
           // in case there is no start, raceId = division.id
 
-          const startTimeNormalize = new Date();
+          console.time('normalizeRace');
           const raceMetadatas = await normalizeRace(objectToPass);
-          logFunctionTime('normalizeRace', startTimeNormalize);
+          console.timeEnd('normalizeRace');
 
-          const startTimeMapRaceQsToSyrf = new Date();
+          console.time('mapRaceQsToSyrf');
           await mapRaceQsToSyrf(objectToPass, raceMetadatas);
-          logFunctionTime('mapRaceQsToSyrf', startTimeMapRaceQsToSyrf);
+          console.timeEnd('mapRaceQsToSyrf');
           console.log(
             `Finished saving race raceQsEvent.original_id = ${raceQsEvent.original_id}`,
           );

--- a/src/syrfDataServices/v1/vesselParticipantTrack.js
+++ b/src/syrfDataServices/v1/vesselParticipantTrack.js
@@ -85,6 +85,7 @@ module.exports = class VesselParticipantTrack {
    * @returns  Feature<LineString>
    */
   getSimplifiedTrack() {
+    console.time('getSimplifiedTrack');
     const coordinateWithTime = [];
     if (this.positions.length > 2) {
       // Turf Line String is unable to process less than 2 position
@@ -105,8 +106,7 @@ module.exports = class VesselParticipantTrack {
         });
       } catch (error) {
         console.error(
-          `Error simplifying tracks: ${
-            error instanceof Error ? error.message : '-'
+          `Error simplifying tracks: ${error instanceof Error ? error.message : '-'
           }. Returning whole track`,
         );
         return {
@@ -148,6 +148,7 @@ module.exports = class VesselParticipantTrack {
         }
       });
     }
+    console.timeEnd('getSimplifiedTrack');
     return {
       type: 'Feature',
       properties: {},
@@ -166,6 +167,8 @@ module.exports = class VesselParticipantTrack {
   createGeoJsonTrack({ competitionUnitId } = {}) {
     const returnFiniteAndNotNull = (num, defaultVal) =>
       isFinite(num) && num !== null ? +num : defaultVal ?? null;
+
+    console.time('generate providedGeoJson');
     const providedGeoJson = {
       type: 'Feature',
       properties: {
@@ -216,6 +219,7 @@ module.exports = class VesselParticipantTrack {
         }),
       },
     };
+    console.timeEnd('generate providedGeoJson');
     const simplifiedGeoJson = {
       ...this.getSimplifiedTrack(),
       properties: {

--- a/src/utils/logUtils.js
+++ b/src/utils/logUtils.js
@@ -1,5 +1,0 @@
-exports.logFunctionTime = function (name, startTime) {
-  const endTime = new Date();
-  const totalTime = (endTime.getTime() - startTime.getTime()) / 1000;
-  console.log(`Function: ${name} takes ${totalTime} seconds`);
-};


### PR DESCRIPTION
1. I used the raw-data-server dev database to run `raceQsSaveToMainDB` to my local main database. The whole process took around 40 hours.
2. In the last time I run, the total memory consumption is around 8 - 13 GB, but it is not too, that is the total memory. 
The `total memory = nodejs application consumption + VS code debugger + VS code`. When we run without debugger, the memory is lower. The memory consumption will be around 4 - 6GB.
So I recommend to run the script with  `--max_old_space_size=8192`
For example: `node --max_old_space_size=8192 scripts/saveToMainDB/raceQsSaveToMainDB`. It will run the script with maximum allowance memory = 8GB.
If we run without `max_old_space_size` the default value = 1.7GB is taken, and the script will hang because of the out of memory exception.
3. I added more logs into the files, so we  can trace when the application is hang. (It run smoothly in my local machine without hanging, but I think we still need to add it).
