### PR TITLE
SNS-726 - Map Americas Cup 2021 to syrf main DB (#188)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raw-data-server",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Server that will be used to transform data to parquet format and perform bulk saving into Permanent Storage",
   "main": "src/main.js",
   "scripts": {

--- a/src/services/mappingsToSyrfDB/mapAmericasCup2021ToSyrf.js
+++ b/src/services/mappingsToSyrfDB/mapAmericasCup2021ToSyrf.js
@@ -1,0 +1,231 @@
+const { saveCompetitionUnit } = require('../saveCompetitionUnit');
+const { createGeometryPoint } = require('../../utils/gisUtils');
+const { vesselEvents, geometryType } = require('../../syrf-schema/enums');
+const elasticsearch = require('../../utils/elasticsearch');
+
+const mapAndSave = async (data, raceMetadata) => {
+  console.log('Saving to main database');
+
+  const event = {
+    id: data.race.id,
+    original_id: data.race.event_name,
+    name: data.race.event_name,
+    approxStartTimeMs: raceMetadata.approx_start_time_ms,
+    approxEndTimeMs: raceMetadata.approx_end_time_ms,
+  };
+
+  const mappedBoats = _mapBoats(data.boats);
+
+  const mappedPositions = _mapPositions(
+    data.boatPositions,
+    data.race.start_time,
+  );
+
+  const { courseSequencedGeometries, markTrackers } = _mapSequencedGeometries(
+    data.buoys,
+  );
+
+  const passingEvents = _mapPassings(
+    data.buoys.roundingTimes,
+    courseSequencedGeometries,
+    data.race.start_time,
+  );
+  const rankings = _mapRankings(
+    data.ranking,
+    data.race.start_time,
+    data.boats.boats,
+  );
+
+  try {
+    await saveCompetitionUnit({
+      race: data.race,
+      event,
+      boats: mappedBoats,
+      positions: mappedPositions,
+      courseSequencedGeometries,
+      markTrackers,
+      markTrackerPositions: data.buoys.buoyPositions.map((pos) => ({
+        timestamp:
+          parseInt(
+            pos.coordinate_interpolator_lat_time + data.race.start_time,
+          ) * 1000,
+        lat: pos.coordinate_interpolator_lat,
+        lon: pos.coordinate_interpolator_lon,
+        markTrackerId: data.buoys.buoys.find(
+          (b) => b.original_id === pos.mark_id,
+        ).id,
+      })),
+      vesselParticipantEvents: passingEvents,
+      rankings,
+      raceMetadata,
+      reuse: {
+        boats: true,
+        event: true,
+      },
+    });
+    await saveToAwsElasticSearch(data.race, data.boats, raceMetadata, data.model);
+  } catch (e) {
+    console.log(e);
+  }
+};
+
+const _mapBoats = ({ boats, teams }) => {
+  return boats.map((b) => {
+    const crew = teams.find((t) => b.team_original_id == t.original_id);
+
+    const vessel = {
+      id: b.id,
+      original_id: b.original_id,
+      publicName: crew.name || crew.abbreviation || '',
+    };
+
+    vessel.crews = [
+      {
+        publicName: crew.name || crew.abbreviation || '',
+      },
+    ];
+    return vessel;
+  });
+};
+
+const _mapPositions = (
+  { boatPositions, boatTwds, boatTwss, boatVmgs },
+  startTime,
+) => {
+  return boatPositions.map((p, i) => {
+    return {
+      timestamp:
+        parseInt(p.coordinate_interpolator_lat_time + startTime) * 1000,
+      lat: p.coordinate_interpolator_lat,
+      lon: p.coordinate_interpolator_lon,
+      vesselId: p.boat_id,
+      cog: p.heading_interpolator_value,
+      sog: p.speed_interpolator_value,
+      windSpeed: boatTwss[i]?.tws_interpolator_value,
+      windDirection: boatTwds[i]?.twd_interpolator_value,
+      vmg: boatVmgs[i]?.vmg_interpolator_value,
+    };
+  });
+};
+
+const _mapSequencedGeometries = ({ buoys, buoyPositions }) => {
+  const courseSequencedGeometries = [];
+  const markTrackers = [];
+
+  buoys.forEach((m, i) => {
+    const markPos = buoyPositions.find((p) => m.original_id === p.mark_id);
+    if (
+      markPos.coordinate_interpolator_lat &&
+      markPos.coordinate_interpolator_lon
+    ) {
+      const mark = createGeometryPoint({
+        lat: markPos.coordinate_interpolator_lat,
+        lon: markPos.coordinate_interpolator_lon,
+        markTrackerId: m.id,
+        properties: {
+          courseObjectId: m.id,
+        },
+      });
+
+      markTrackers.push({
+        id: m.id,
+      });
+
+      mark.order = i;
+      courseSequencedGeometries.push(mark);
+    }
+  });
+
+  return {
+    courseSequencedGeometries,
+    markTrackers,
+  };
+};
+
+const _mapPassings = (passings, geometry, startTime) => {
+  return passings.map((p) => {
+    const eventGeometry = geometry.find((g) => {
+      return g.order === p.mark_number;
+    });
+
+    if (!eventGeometry) {
+      return null;
+    }
+    const eventType =
+      eventGeometry.geometryType === geometryType.LINESTRING
+        ? vesselEvents.insideCrossing
+        : vesselEvents.rounding;
+    return {
+      competitionUnitId: p.race_id,
+      vesselId: p.boat_id,
+      markId: eventGeometry.properties.courseObjectId,
+      eventType,
+      eventTime: parseInt(p.time + startTime) * 1000,
+    };
+  });
+};
+
+const _mapRankings = (rankings, startTime, boats) => {
+  const ranksMap = rankings?.reduce((acc, r) => {
+    const finishTime = parseInt(r.rank_interpolator_time + startTime) * 1000;
+    const boatData = boats.find((b) => b.id === r.boat_id);
+    const existingBoatRank = acc[r.boat_id];
+    const isLatestRank = existingBoatRank?.finishTime > boatData?.finishTime;
+    if ((!existingBoatRank && boatData) || isLatestRank) {
+      acc[r.boat_id] = {
+        vesselId: r.boat_id,
+        finishTime,
+        elapsedTime: finishTime - startTime,
+      };
+    }
+    return acc;
+  }, {});
+
+  return ranksMap ? Object.values(ranksMap) : undefined;
+};
+
+const saveToAwsElasticSearch = async (race, { boats, teams }, raceMetadata, boatModels) => {
+  const boatNames = [];
+  const boatIdentifiers = [];
+
+  boats.forEach((b) => {
+    boatIdentifiers.push(b.original_id);
+    const boatName = teams.find((t) => b.team_original_id === t.original_id)?.name;
+    if (boatName) {
+      boatNames.push(boatName);
+    }
+  });
+
+  const body = {
+    id: race.id,
+    name: raceMetadata.name,
+    event_name: race.event_name,
+    event: raceMetadata.event,
+    source: raceMetadata.source,
+    url: raceMetadata.url,
+    start_country: raceMetadata.start_country,
+    start_city: raceMetadata.start_city,
+    start_year: Number(raceMetadata.start_year),
+    start_month: Number(raceMetadata.start_month),
+    start_day: Number(raceMetadata.start_day),
+    approx_start_time_ms: Number(raceMetadata.approx_start_time_ms),
+    approx_end_time_ms: Number(raceMetadata.approx_end_time_ms),
+    approx_duration_ms: Number(raceMetadata.approx_duration_ms),
+    approx_start_point: raceMetadata.approx_start_point,
+    approx_end_point: raceMetadata.approx_end_point,
+    approx_mid_point: raceMetadata.approx_mid_point,
+    bounding_box: raceMetadata.bounding_box,
+    approx_area_sq_km: raceMetadata.approx_area_sq_km,
+    approx_distance_km: raceMetadata.approx_distance_km,
+    num_boats: raceMetadata.num_boats,
+    avg_time_between_positions: raceMetadata.avg_time_between_positions,
+    boat_models: boatModels,
+    boat_identifiers: boatIdentifiers,
+    boat_names: boatNames,
+    handicap_rules: raceMetadata.handicap_rules,
+    unstructured_text: [],
+  };
+
+  await elasticsearch.indexRace(race.id, body);
+};
+module.exports = mapAndSave;

--- a/src/services/non-automatable/saveAmericasCup2021Data.js
+++ b/src/services/non-automatable/saveAmericasCup2021Data.js
@@ -1,19 +1,24 @@
 const { v4: uuidv4 } = require('uuid');
-
-const { SAVE_DB_POSITION_CHUNK_COUNT } = require('../../constants');
-const db = require('../../models');
 const s3Util = require('../s3Util');
 const {
   normalizeRace,
 } = require('../normalization/non-automatable/normalizeAmericascup2021');
+const { SOURCE } = require('../../constants');
+const { getExistingData } = require('../scrapedDataResult');
 
 const saveAmericasCup2021Data = async (data) => {
-  const transaction = await db.sequelize.transaction();
   try {
     let race = {};
     let boatPositions = [];
     let boats = [];
     let teams = [];
+    let boatTwds = [];
+    let boatTwss = [];
+    let boatVmgs = [];
+    let buoys = [];
+    let buoyPositions = [];
+    let roundingTimes = [];
+    let boatRanks = [];
     if (data.race) {
       let raceId = uuidv4();
       race = {
@@ -30,6 +35,7 @@ const saveAmericasCup2021Data = async (data) => {
         last_packet_time: data.race.lastPacketTime,
         packet_id: data.race.courseInfo.packetId,
         start_time: data.race.courseInfo.startTime,
+        race_start_time: data.race.raceStartTime,
         num_legs: data.race.courseInfo.numLegs,
         course_angle: data.race.courseInfo.courseAngle,
         race_status: data.race.courseInfo.raceStatus,
@@ -39,23 +45,6 @@ const saveAmericasCup2021Data = async (data) => {
         scene_center_utm_lat: data.race.sceneCenterUTM.y,
         sim_time: data.race.simTime,
       };
-      await db.americasCup2021Race.create(race, { transaction });
-
-      let raceStatus = data.race.raceStatusInterp.valHistory.map((row) => {
-        return {
-          id: uuidv4(),
-          race_id: raceId,
-          race_original_id: data.race.raceId,
-          race_status_interpolator_value: row[0],
-          race_status_interpolator_time: row[1],
-        };
-      });
-
-      await db.americasCup2021RaceStatus.bulkCreate(raceStatus, {
-        ignoreDuplicates: true,
-        validate: true,
-        transaction,
-      });
 
       teams = data.appConfig.teams.map((row) => {
         return {
@@ -67,7 +56,7 @@ const saveAmericasCup2021Data = async (data) => {
           abbreviation: row.abbr,
           flag_id: row.flag_id,
           color: row.color,
-          boat_name: row.boatmodel?.name,
+          boat_model_name: row.boatmodel?.name,
           top_mast_offset_x: row.boatmodel?.topMastOffset.x,
           top_mast_offset_y: row.boatmodel?.topMastOffset.y,
           top_mast_offset_z: row.boatmodel?.topMastOffset.z,
@@ -79,12 +68,6 @@ const saveAmericasCup2021Data = async (data) => {
         };
       });
 
-      await db.americasCup2021Team.bulkCreate(teams, {
-        ignoreDuplicates: true,
-        validate: true,
-        transaction,
-      });
-
       let boatKeys = Object.keys(data.race.boats);
       boats = boatKeys.map((key) => {
         return {
@@ -94,18 +77,13 @@ const saveAmericasCup2021Data = async (data) => {
           original_id: data.race.boats[key].boatId,
           team_id: teams.find(
             (x) => x.original_id === data.race.boats[key].teamId,
-          ).id,
+          )?.id,
           team_original_id: data.race.boats[key].teamId,
           current_leg: data.race.boats[key].current_leg,
           distance_to_leader: data.race.boats[key].distance_to_leader,
           rank: data.race.boats[key].rank,
           foil_move_time: data.race.boats[key].foilMoveTime,
         };
-      });
-      await db.americasCup2021Boat.bulkCreate(boats, {
-        ignoreDuplicates: true,
-        validate: true,
-        transaction,
       });
 
       boatKeys.map((bKey) => {
@@ -159,225 +137,6 @@ const saveAmericasCup2021Data = async (data) => {
         }
       });
 
-      const _boatPositions = boatPositions.slice();
-      while (_boatPositions.length > 0) {
-        const splicedArray = _boatPositions.splice(
-          0,
-          SAVE_DB_POSITION_CHUNK_COUNT,
-        );
-        await db.americasCup2021BoatPosition.bulkCreate(splicedArray, {
-          ignoreDuplicates: true,
-          validate: true,
-          transaction,
-        });
-      }
-
-      let boatLeftFoilPositions = [];
-
-      boatKeys.map((bKey) => {
-        for (const boatIndex in data.race.boats[bKey].leftFoilPosition
-          .valHistory) {
-          let boatLeftFoilPosition = {
-            id: uuidv4(),
-            race_id: raceId,
-            race_original_id: data.race.raceId,
-            boat_id: boats.find(
-              (x) => x.original_id === data.race.boats[bKey].boatId,
-            ).id,
-            boat_original_id: data.race.boats[bKey].boatId,
-            left_foil_position_interpolator_value:
-              data.race.boats[bKey].leftFoilPosition.valHistory[boatIndex][0],
-            left_foil_position_interpolator_time:
-              data.race.boats[bKey].leftFoilPosition.valHistory[boatIndex][1],
-          };
-          boatLeftFoilPositions.push(boatLeftFoilPosition);
-        }
-      });
-
-      await db.americasCup2021BoatLeftFoilPosition.bulkCreate(
-        boatLeftFoilPositions,
-        {
-          ignoreDuplicates: true,
-          validate: true,
-          transaction,
-        },
-      );
-
-      let boatLeftFoilStates = [];
-
-      boatKeys.map((bKey) => {
-        for (const boatIndex in data.race.boats[bKey].leftFoilState
-          .valHistory) {
-          let boatLeftFoilState = {
-            id: uuidv4(),
-            race_id: raceId,
-            race_original_id: data.race.raceId,
-            boat_id: boats.find(
-              (x) => x.original_id === data.race.boats[bKey].boatId,
-            ).id,
-            boat_original_id: data.race.boats[bKey].boatId,
-            left_foil_state_interpolator_value:
-              data.race.boats[bKey].leftFoilState.valHistory[boatIndex][0],
-            left_foil_state_interpolator_time:
-              data.race.boats[bKey].leftFoilState.valHistory[boatIndex][1],
-          };
-          boatLeftFoilStates.push(boatLeftFoilState);
-        }
-      });
-
-      await db.americasCup2021BoatLeftFoilState.bulkCreate(boatLeftFoilStates, {
-        ignoreDuplicates: true,
-        validate: true,
-        transaction,
-      });
-
-      let boatRightFoilPositions = [];
-
-      boatKeys.map((bKey) => {
-        for (const boatIndex in data.race.boats[bKey].rightFoilPosition
-          .valHistory) {
-          let boatRightFoilPosition = {
-            id: uuidv4(),
-            race_id: raceId,
-            race_original_id: data.race.raceId,
-            boat_id: boats.find(
-              (x) => x.original_id === data.race.boats[bKey].boatId,
-            ).id,
-            boat_original_id: data.race.boats[bKey].boatId,
-            right_foil_position_interpolator_value:
-              data.race.boats[bKey].rightFoilPosition.valHistory[boatIndex][0],
-            right_foil_position_interpolator_time:
-              data.race.boats[bKey].rightFoilPosition.valHistory[boatIndex][1],
-          };
-          boatRightFoilPositions.push(boatRightFoilPosition);
-        }
-      });
-
-      await db.americasCup2021BoatRightFoilPosition.bulkCreate(
-        boatRightFoilPositions,
-        {
-          ignoreDuplicates: true,
-          validate: true,
-          transaction,
-        },
-      );
-
-      let boatRightFoilStates = [];
-
-      boatKeys.map((bKey) => {
-        for (const boatIndex in data.race.boats[bKey].rightFoilState
-          .valHistory) {
-          let boatRightFoilState = {
-            id: uuidv4(),
-            race_id: raceId,
-            race_original_id: data.race.raceId,
-            boat_id: boats.find(
-              (x) => x.original_id === data.race.boats[bKey].boatId,
-            ).id,
-            boat_original_id: data.race.boats[bKey].boatId,
-            right_foil_state_interpolator_value:
-              data.race.boats[bKey].rightFoilState.valHistory[boatIndex][0],
-            right_foil_state_interpolator_time:
-              data.race.boats[bKey].rightFoilState.valHistory[boatIndex][1],
-          };
-          boatRightFoilStates.push(boatRightFoilState);
-        }
-      });
-
-      await db.americasCup2021BoatRightFoilState.bulkCreate(
-        boatRightFoilStates,
-        {
-          ignoreDuplicates: true,
-          validate: true,
-          transaction,
-        },
-      );
-
-      let boatLegs = [];
-
-      boatKeys.map((bKey) => {
-        for (const boatIndex in data.race.boats[bKey].legInterp.valHistory) {
-          let boatLeg = {
-            id: uuidv4(),
-            race_id: raceId,
-            race_original_id: data.race.raceId,
-            boat_id: boats.find(
-              (x) => x.original_id === data.race.boats[bKey].boatId,
-            ).id,
-            boat_original_id: data.race.boats[bKey].boatId,
-            leg_interpolator_value:
-              data.race.boats[bKey].legInterp.valHistory[boatIndex][0],
-            leg_interpolator_time:
-              data.race.boats[bKey].legInterp.valHistory[boatIndex][1],
-          };
-          boatLegs.push(boatLeg);
-        }
-      });
-
-      await db.americasCup2021BoatLeg.bulkCreate(boatLegs, {
-        ignoreDuplicates: true,
-        validate: true,
-        transaction,
-      });
-
-      let boatPenalties = [];
-
-      boatKeys.map((bKey) => {
-        for (const boatIndex in data.race.boats[bKey].penaltyCountInterp
-          .valHistory) {
-          let boatPenalty = {
-            id: uuidv4(),
-            race_id: raceId,
-            race_original_id: data.race.raceId,
-            boat_id: boats.find(
-              (x) => x.original_id === data.race.boats[bKey].boatId,
-            ).id,
-            boat_original_id: data.race.boats[bKey].boatId,
-            penalty_count_interpolator_value:
-              data.race.boats[bKey].penaltyCountInterp.valHistory[boatIndex][0],
-            penalty_count_interpolator_time:
-              data.race.boats[bKey].penaltyCountInterp.valHistory[boatIndex][1],
-          };
-          boatPenalties.push(boatPenalty);
-        }
-      });
-
-      await db.americasCup2021BoatPenalty.bulkCreate(boatPenalties, {
-        ignoreDuplicates: true,
-        validate: true,
-        transaction,
-      });
-
-      let boatProtests = [];
-
-      boatKeys.map((bKey) => {
-        for (const boatIndex in data.race.boats[bKey].protestInterp
-          .valHistory) {
-          let boatProtest = {
-            id: uuidv4(),
-            race_id: raceId,
-            race_original_id: data.race.raceId,
-            boat_id: boats.find(
-              (x) => x.original_id === data.race.boats[bKey].boatId,
-            ).id,
-            boat_original_id: data.race.boats[bKey].boatId,
-            protest_interpolator_value:
-              data.race.boats[bKey].protestInterp.valHistory[boatIndex][0],
-            protest_interpolator_time:
-              data.race.boats[bKey].protestInterp.valHistory[boatIndex][1],
-          };
-          boatProtests.push(boatProtest);
-        }
-      });
-
-      await db.americasCup2021BoatProtest.bulkCreate(boatProtests, {
-        ignoreDuplicates: true,
-        validate: true,
-        transaction,
-      });
-
-      let boatRanks = [];
-
       boatKeys.map((bKey) => {
         for (const boatIndex in data.race.boats[bKey].rankInterp.valHistory) {
           let boatRank = {
@@ -396,95 +155,6 @@ const saveAmericasCup2021Data = async (data) => {
           boatRanks.push(boatRank);
         }
       });
-
-      await db.americasCup2021BoatRank.bulkCreate(boatRanks, {
-        ignoreDuplicates: true,
-        validate: true,
-        transaction,
-      });
-
-      let boatRudderAngles = [];
-
-      boatKeys.map((bKey) => {
-        for (const boatIndex in data.race.boats[bKey].ruddleAngle.valHistory) {
-          let boatRudderAngle = {
-            id: uuidv4(),
-            race_id: raceId,
-            race_original_id: data.race.raceId,
-            boat_id: boats.find(
-              (x) => x.original_id === data.race.boats[bKey].boatId,
-            ).id,
-            boat_original_id: data.race.boats[bKey].boatId,
-            rudder_angle__value:
-              data.race.boats[bKey].ruddleAngle.valHistory[boatIndex][0],
-            rudder_angle__time:
-              data.race.boats[bKey].ruddleAngle.valHistory[boatIndex][1],
-          };
-          boatRudderAngles.push(boatRudderAngle);
-        }
-      });
-
-      await db.americasCup2021BoatRudderAngle.bulkCreate(boatRudderAngles, {
-        ignoreDuplicates: true,
-        validate: true,
-        transaction,
-      });
-
-      let boatSows = [];
-
-      boatKeys.map((bKey) => {
-        for (const boatIndex in data.race.boats[bKey].sowInterp.valHistory) {
-          let boatSow = {
-            id: uuidv4(),
-            race_id: raceId,
-            race_original_id: data.race.raceId,
-            boat_id: boats.find(
-              (x) => x.original_id === data.race.boats[bKey].boatId,
-            ).id,
-            boat_original_id: data.race.boats[bKey].boatId,
-            sow_interpolator_value:
-              data.race.boats[bKey].sowInterp.valHistory[boatIndex][0],
-            sow_interpolator_time:
-              data.race.boats[bKey].sowInterp.valHistory[boatIndex][1],
-          };
-          boatSows.push(boatSow);
-        }
-      });
-
-      await db.americasCup2021BoatSow.bulkCreate(boatSows, {
-        ignoreDuplicates: true,
-        validate: true,
-        transaction,
-      });
-
-      let boatStatuses = [];
-
-      boatKeys.map((bKey) => {
-        for (const boatIndex in data.race.boats[bKey].statusInterp.valHistory) {
-          let boatStatus = {
-            id: uuidv4(),
-            race_id: raceId,
-            race_original_id: data.race.raceId,
-            boat_id: boats.find(
-              (x) => x.original_id === data.race.boats[bKey].boatId,
-            ).id,
-            boat_original_id: data.race.boats[bKey].boatId,
-            status_interpolator_value:
-              data.race.boats[bKey].statusInterp.valHistory[boatIndex][0],
-            status_interpolator_time:
-              data.race.boats[bKey].statusInterp.valHistory[boatIndex][1],
-          };
-          boatStatuses.push(boatStatus);
-        }
-      });
-
-      await db.americasCup2021BoatStatus.bulkCreate(boatStatuses, {
-        ignoreDuplicates: true,
-        validate: true,
-        transaction,
-      });
-
-      let boatTwds = [];
 
       boatKeys.map((bKey) => {
         for (const boatIndex in data.race.boats[bKey].twdInterp.valHistory) {
@@ -505,18 +175,6 @@ const saveAmericasCup2021Data = async (data) => {
         }
       });
 
-      const _boatTwds = boatTwds.slice();
-      while (_boatTwds.length > 0) {
-        const splicedArray = _boatTwds.splice(0, SAVE_DB_POSITION_CHUNK_COUNT);
-        await db.americasCup2021BoatTwd.bulkCreate(splicedArray, {
-          ignoreDuplicates: true,
-          validate: true,
-          transaction,
-        });
-      }
-
-      let boatTwss = [];
-
       boatKeys.map((bKey) => {
         for (const boatIndex in data.race.boats[bKey].twsInterp.valHistory) {
           let boatTws = {
@@ -535,18 +193,6 @@ const saveAmericasCup2021Data = async (data) => {
           boatTwss.push(boatTws);
         }
       });
-
-      const _boatTwss = boatTwss.slice();
-      while (_boatTwss.length > 0) {
-        const splicedArray = _boatTwss.splice(0, SAVE_DB_POSITION_CHUNK_COUNT);
-        await db.americasCup2021BoatTws.bulkCreate(splicedArray, {
-          ignoreDuplicates: true,
-          validate: true,
-          transaction,
-        });
-      }
-
-      let boatVmgs = [];
 
       boatKeys.map((bKey) => {
         for (const boatIndex in data.race.boats[bKey].vmgInterp.valHistory) {
@@ -567,18 +213,8 @@ const saveAmericasCup2021Data = async (data) => {
         }
       });
 
-      const _boatVmgs = boatVmgs.slice();
-      while (_boatVmgs.length > 0) {
-        const splicedArray = _boatVmgs.splice(0, SAVE_DB_POSITION_CHUNK_COUNT);
-        await db.americasCup2021BoatVmg.bulkCreate(splicedArray, {
-          ignoreDuplicates: true,
-          validate: true,
-          transaction,
-        });
-      }
-
       let buoyKeys = Object.keys(data.race.buoys);
-      let buoys = buoyKeys.map((key) => {
+      buoys = buoyKeys.map((key) => {
         return {
           id: uuidv4(),
           race_id: raceId,
@@ -589,13 +225,7 @@ const saveAmericasCup2021Data = async (data) => {
           last_leg_visible: data.race.buoys[key].lastLegVisible,
         };
       });
-      await db.americasCup2021Buoy.bulkCreate(buoys, {
-        ignoreDuplicates: true,
-        validate: true,
-        transaction,
-      });
 
-      let buoyPositions = [];
       buoyKeys.map((key) => {
         for (const buoyIndex in data.race.buoys[key].headingInterp.valHistory) {
           let buoyPosition = {
@@ -628,74 +258,6 @@ const saveAmericasCup2021Data = async (data) => {
         }
       });
 
-      const _buoyPositions = buoyPositions.slice();
-      while (_buoyPositions.length > 0) {
-        const splicedArray = _buoyPositions.splice(
-          0,
-          SAVE_DB_POSITION_CHUNK_COUNT,
-        );
-        await db.americasCup2021BuoyPosition.bulkCreate(splicedArray, {
-          ignoreDuplicates: true,
-          validate: true,
-          transaction,
-        });
-      }
-
-      let buoyPositionStates = [];
-      buoyKeys.map((key) => {
-        for (const stateIndex in data.race.buoys[key].stateInterp.valHistory) {
-          let buoyPositionState = {
-            id: uuidv4(),
-            race_id: raceId,
-            race_original_id: data.race.raceId,
-            mark_id: data.race.buoys[key].markId,
-            state_interpolator_value:
-              data.race.buoys[key].stateInterp.valHistory[stateIndex][0],
-            state_interpolator_time:
-              data.race.buoys[key].stateInterp.valHistory[stateIndex][1],
-          };
-          buoyPositionStates.push(buoyPositionState);
-        }
-      });
-
-      const _buoyPositionState = buoyPositionStates.slice();
-      while (_buoyPositionState.length > 0) {
-        const splicedArray = _buoyPositionState.splice(
-          0,
-          SAVE_DB_POSITION_CHUNK_COUNT,
-        );
-        await db.americasCup2021BuoyPositionState.bulkCreate(splicedArray, {
-          ignoreDuplicates: true,
-          validate: true,
-          transaction,
-        });
-      }
-
-      let rankings = data.race.rankings.map((row) => {
-        return {
-          id: uuidv4(),
-          race_id: raceId,
-          race_original_id: data.race.raceId,
-          boat_id: boats.find((x) => x.original_id === row.boat_id).id,
-          boat_original_id: row.boat_id,
-          rank: row.rank,
-          leg: row.leg,
-          dtl: row.dtl,
-          secs_to_leader: row.secsToLeader,
-          penalty_count: row.penaltyCount,
-          protest_active: row.protestActive,
-          status: row.status,
-          speed: row.speed,
-        };
-      });
-
-      await db.americasCup2021Ranking.bulkCreate(rankings, {
-        ignoreDuplicates: true,
-        validate: true,
-        transaction,
-      });
-
-      let roundingTimes = [];
       let roundingTimesKeys = Object.keys(data.race.roundingTimesByMarkId);
       roundingTimesKeys.map((rkey) => {
         let keys = Object.keys(data.race.roundingTimesByMarkId[rkey]);
@@ -717,156 +279,45 @@ const saveAmericasCup2021Data = async (data) => {
           roundingTimes.push(roundingTime);
         }
       });
-
-      await db.americasCup2021RoundingTime.bulkCreate(roundingTimes, {
-        ignoreDuplicates: true,
-        validate: true,
-        transaction,
-      });
-
-      let windDatas = [];
-      for (
-        var i = 0;
-        i < data.race.windData.downwindLaylineAngle.valHistory.length;
-        i++
-      ) {
-        let windData = {
-          id: uuidv4(),
-          race_id: raceId,
-          race_original_id: data.race.raceId,
-          wind_heading_value: data.race.windData.windHeading.valHistory[i][0],
-          wind_heading_time: data.race.windData.windHeading.valHistory[i][1],
-          upwind_layline_angle_value:
-            data.race.windData.upwindLaylineAngle.valHistory[i][0],
-          upwind_layline_angle_time:
-            data.race.windData.upwindLaylineAngle.valHistory[i][1],
-          downwind_layline_angle_value:
-            data.race.windData.downwindLaylineAngle.valHistory[i][0],
-          downwind_layline_angle_time:
-            data.race.windData.downwindLaylineAngle.valHistory[i][1],
-          wind_speed_value: data.race.windData.windSpeed.valHistory[i][0],
-          wind_speed_time: data.race.windData.windSpeed.valHistory[i][1],
-        };
-        windDatas.push(windData);
-      }
-
-      const _windDatas = windDatas.slice();
-      while (_windDatas.length > 0) {
-        const splicedArray = _windDatas.splice(0, SAVE_DB_POSITION_CHUNK_COUNT);
-        await db.americasCup2021WindData.bulkCreate(splicedArray, {
-          ignoreDuplicates: true,
-          validate: true,
-          transaction,
-        });
-      }
-
-      let windPoints = [];
-      let windPointKeys = Object.keys(data.race.windPoints);
-
-      windPointKeys.map((wpKey) => {
-        for (
-          var i = 0;
-          i < data.race.windPoints[wpKey].headingInterp.valHistory.length;
-          i++
-        ) {
-          let windPoint = {
-            id: uuidv4(),
-            race_id: raceId,
-            race_original_id: data.race.raceId,
-            wind_point_id: data.race.windPoints[wpKey].Id,
-            coordinate_interpolator_lon:
-              data.race.windPoints[wpKey].coordIntepolator.yCerp.valHistory[
-                i
-              ][0],
-            coordinate_interpolator_lon_time:
-              data.race.windPoints[wpKey].coordIntepolator.yCerp.valHistory[
-                i
-              ][1],
-            coordinate_interpolator_lat:
-              data.race.windPoints[wpKey].coordIntepolator.xCerp.valHistory[
-                i
-              ][0],
-            coordinate_interpolator_lat_time:
-              data.race.windPoints[wpKey].coordIntepolator.xCerp.valHistory[
-                i
-              ][1],
-            heading_interpolator_value:
-              data.race.windPoints[wpKey].headingInterp.valHistory[i][0],
-            heading_interpolator_lat_time:
-              data.race.windPoints[wpKey].headingInterp.valHistory[i][1],
-            wind_speed_interpolator_value:
-              data.race.windPoints[wpKey].windSpeed.valHistory[i][0],
-            wind_speed_interpolator_time:
-              data.race.windPoints[wpKey].windSpeed.valHistory[i][1],
-          };
-          windPoints.push(windPoint);
-        }
-      });
-
-      const _windPoints = windPoints.slice();
-      while (_windPoints.length > 0) {
-        const splicedArray = _windPoints.splice(
-          0,
-          SAVE_DB_POSITION_CHUNK_COUNT,
-        );
-        await db.americasCup2021WindPoint.bulkCreate(splicedArray, {
-          ignoreDuplicates: true,
-          validate: true,
-          transaction,
-        });
-      }
-
-      let boundaryPackets = [];
-      data.race.courseBoundary.boundaryPackets.valHistory.forEach((row) => {
-        row[0].points.forEach((point) => {
-          let boundaryPacket = {
-            id: uuidv4(),
-            race_id: raceId,
-            race_original_id: data.race.raceId,
-            packet_id: row[0].packetId,
-            coordinate_interpolator_lon: point[0],
-            coordinate_interpolator_lat: point[1],
-          };
-          boundaryPackets.push(boundaryPacket);
-        });
-      });
-
-      const _boundaryPackets = boundaryPackets.slice();
-      while (_boundaryPackets.length > 0) {
-        const splicedArray = _boundaryPackets.splice(
-          0,
-          SAVE_DB_POSITION_CHUNK_COUNT,
-        );
-        await db.americasCup2021BoundaryPacket.bulkCreate(splicedArray, {
-          ignoreDuplicates: true,
-          validate: true,
-          transaction,
-        });
-      }
     }
     if (data.race) {
       let normalizeData = {
-        AmericasCup2021Race: [race],
-        AmericasCup2021Boat: boats,
-        AmericasCup2021Position: boatPositions,
-        AmericasCup2021Team: teams,
-        AmericasCup2021Model: [data.appConfig.defaultboatmodel.name],
+        race,
+        boats: {
+          boats,
+          teams,
+        },
+        boatPositions: {
+          boatPositions,
+          boatTwds,
+          boatTwss,
+          boatVmgs,
+        },
+        buoys: {
+          buoys,
+          buoyPositions,
+          roundingTimes,
+        },
+        ranking: boatRanks,
+        model: [data.appConfig.defaultboatmodel.name],
       };
-      await normalizeRace(normalizeData, transaction);
+      await normalizeRace(normalizeData);
     }
-    await transaction.commit();
   } catch (error) {
     console.log(error);
-    await transaction.rollback();
   }
 };
 
 const downloadAndProcessFiles = async (bucketName) => {
   let fileNames = await s3Util.listAllKeys(bucketName);
+  const existingData = await getExistingData(SOURCE.AMERICASCUP2021);
+
   for (const index in fileNames) {
     try {
       const fileName = fileNames[index];
-      console.log(`Processing file ${fileName} ${index} of ${fileNames.length-1}`);
+      console.log(
+        `Processing file ${fileName} ${index} of ${fileNames.length - 1}`,
+      );
       let rawData = await s3Util.getObject(fileName, bucketName);
       let destructuredFileName = fileName.split('-');
       let raceData = JSON.parse(rawData);
@@ -874,10 +325,7 @@ const downloadAndProcessFiles = async (bucketName) => {
       raceData.raceName = destructuredFileName[2]
         .replace('.json', '')
         .replace('_', ' ');
-      let race = await db.americasCup2021Race.findOne({
-        where: { original_id: raceData.race.raceId.toString() },
-      });
-      if (!race) {
+      if (!existingData.find((e) => e.original_id == raceData.race.raceId)) {
         await saveAmericasCup2021Data(raceData);
       } else {
         console.log(`Race ${fileName} already exists`);

--- a/src/services/normalization/non-automatable/normalizeAmericascup2021.js
+++ b/src/services/normalization/non-automatable/normalizeAmericascup2021.js
@@ -1,5 +1,4 @@
 const turf = require('@turf/turf');
-const db = require('../../../models');
 const {
   createBoatToPositionDictionary,
   positionsToFeatureCollection,
@@ -8,27 +7,17 @@ const {
   getCenterOfMassOfPositions,
   findAverageLength,
   createRace,
-  allPositionsToFeatureCollection,
 } = require('../../../utils/gisUtils');
-const { uploadGeoJsonToS3 } = require('../../uploadUtil');
+const mapAndSave = require('../../mappingsToSyrfDB/mapAmericasCup2021ToSyrf');
 
-const normalizeRace = async (
-  {
-    AmericasCup2021Race,
-    AmericasCup2021Boat,
-    AmericasCup2021Position,
-    AmericasCup2021Team,
-    AmericasCup2021Model,
-  },
-  transaction,
-) => {
+const normalizeRace = async (data) => {
   const SOURCE = 'AMERICASCUP2021';
-  const race = AmericasCup2021Race[0];
-  const positions = AmericasCup2021Position;
-  const boats = AmericasCup2021Boat;
-  const startTime = race.start_time * 1000;
-  const endTime = (race.max_race_time - race.min_race_time) * 1000 + startTime;
-  const boatModels = AmericasCup2021Model;
+  const race = data.race;
+  const positions = data.boatPositions.boatPositions;
+  const boats = data.boats.boats;
+  const startTime = (race.start_time + race.race_start_time) * 1000;
+  const endTime = (race.max_race_time + race.start_time) * 1000;
+  const boatModels = data.model;
 
   const boatNames = [];
   const boatIdentifiers = [];
@@ -37,9 +26,9 @@ const normalizeRace = async (
 
   boats.forEach((b) => {
     boatIdentifiers.push(b.original_id);
-    let team = AmericasCup2021Team.find((t) => t.id === b.team_id);
-    if (team?.boat_name) {
-      boatNames.push(team?.boat_name);
+    let team = data.boats.teams.find((t) => t.id === b.team_id);
+    if (team?.name) {
+      boatNames.push(team.name);
     }
   });
 
@@ -94,24 +83,7 @@ const normalizeRace = async (
     true, // Skip elastic search for now since race does not have url
   );
 
-  const metadata = await db.readyAboutRaceMetadata.findOne({
-    where: {
-      id: raceMetadata.id,
-    },
-    raw: true,
-  });
-
-  if (!metadata) {
-    await db.readyAboutRaceMetadata.create(raceMetadata, {
-      fields: Object.keys(raceMetadata),
-      transaction,
-    });
-    const tracksGeojson = JSON.stringify(
-      allPositionsToFeatureCollection(boatsToSortedPositions),
-    );
-    await uploadGeoJsonToS3(race.id, tracksGeojson, SOURCE, transaction);
-  }
-  return raceMetadata;
+  await mapAndSave(data, raceMetadata);
 };
 
 exports.normalizeRace = normalizeRace;


### PR DESCRIPTION
* SNS-726 - Map Americas Cup 2021 to syrf main DB

* recalculate race time

* save to elastic search

* read and save from original object

* Minor fix

* Fix minor issues on americas cup 2021 like boat names and models

Co-authored-by: Jackson Tan <jackson.tan.s@gmail.com>